### PR TITLE
Replaced allModels with withModel

### DIFF
--- a/examples/AST.hs
+++ b/examples/AST.hs
@@ -48,12 +48,12 @@ main = withDefaultClingo $ do
         literal <$> symbolicAtomFromSymbol s sym
         
     liftIO $ putStrLn "Solving with enable = false..."
-    withSolver [] (allModels >=> mapM_ printModel)
+    withSolver [] (withModel printModel)
 
     liftIO $ putStrLn "Solving with enable = true..."
     assignExternal lit TruthTrue
-    withSolver [] (allModels >=> mapM_ printModel)
+    withSolver [] (withModel printModel)
 
     liftIO $ putStrLn "Solving with enable = false..."
     assignExternal lit TruthFalse
-    withSolver [] (allModels >=> mapM_ printModel)
+    withSolver [] (withModel printModel)

--- a/examples/Backend.hs
+++ b/examples/Backend.hs
@@ -35,4 +35,4 @@ main = withDefaultClingo $ do
                   , atoms !! 2]
             ]
 
-    withSolver [] (allModels >=> mapM_ printModel)
+    withSolver [] (withModel printModel)

--- a/examples/Configuration.hs
+++ b/examples/Configuration.hs
@@ -32,4 +32,4 @@ main = withDefaultClingo $ do
     
     addProgram "base" [] "a :- not b. b :- not a."
     ground [Part "base" []] Nothing
-    withSolver [] (allModels >=> mapM_ printModel)
+    withSolver [] (withModel printModel)

--- a/examples/Control.hs
+++ b/examples/Control.hs
@@ -21,4 +21,4 @@ main :: IO ()
 main = withDefaultClingo $ do
     addProgram "base" [] "a :- not b. b :- not a."
     ground [Part "base" []] Nothing
-    withSolver [] (allModels >=> mapM_ printModel)
+    withSolver [] (withModel printModel)

--- a/examples/DotPropagator.hs
+++ b/examples/DotPropagator.hs
@@ -39,5 +39,5 @@ main = withDefaultClingo $ do
         }
     loadProgram path
     ground [Part "base" []] Nothing
-    withSolver [] (void . allModels)
+    withSolver [] (void . withModel (const $ return ()))
     liftIO (putChar '\n')

--- a/examples/GroundCallback.hs
+++ b/examples/GroundCallback.hs
@@ -32,4 +32,4 @@ main =
         ground
             [Part "base" []]
             (Just $ \l t s -> runExceptT (groundCallback l t s))
-        withSolver [] (allModels >=> mapM_ printModel)
+        withSolver [] (withModel printModel)

--- a/examples/Model.hs
+++ b/examples/Model.hs
@@ -44,4 +44,4 @@ main = getArgs >>= \args ->
     withClingo (defaultClingo { clingoArgs = args }) $ do
         addProgram "base" [] "1 {a; b} 1. #show c : b. #show a/0."
         ground [Part "base" []] Nothing
-        withSolver [] (allModels >=> mapM_ printSolution)
+        withSolver [] (withModel printSolution)

--- a/examples/Statistics.hs
+++ b/examples/Statistics.hs
@@ -36,7 +36,7 @@ main = withDefaultClingo $ do
     -- Ground and solve a simple program
     addProgram "base" [] "a :- not b. b :- not a."
     ground [Part "base" []] Nothing
-    _ <- withSolver [] (allModels >=> mapM_ printModel)
+    _ <- withSolver [] (withModel printModel)
     stats <- statistics
 
     -- Print whole stats tree

--- a/examples/TheoryAtoms.hs
+++ b/examples/TheoryAtoms.hs
@@ -57,4 +57,4 @@ main =
         ground [Part "base" []] Nothing
         lit <- theory =<< theoryAtoms
         flip addGroundStatements [assume [lit]] =<< backend
-        withSolver [] (allModels >=> mapM_ printModel)
+        withSolver [] (withModel printModel)


### PR DESCRIPTION
allModels collected pointers pointing to the same model object which was
obviously not the intended use case. withModel invokes a provided
callback with each model as an argument leaving peeking of the model
object to the caller.
I'm not particularly happy with this solution but at least it works.